### PR TITLE
Tailer reader method

### DIFF
--- a/components/core-agent/src/tailer/async_read.rs
+++ b/components/core-agent/src/tailer/async_read.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, ReadBuf, Result as IoResult};
 ///
 /// This assumes any stop conditions are treated as EOFs. See [this code](https://github.com/vectordotdev/vector/blob/master/src/async_read.rs)
 
-pub trait AsyncReadExt: AsyncRead {
+pub trait CustomAsyncReadExt: AsyncRead {
     fn read_until_future<F>(self, until: F) -> ReadUntil<Self, F>
     where
         Self: Sized,
@@ -23,7 +23,7 @@ pub trait AsyncReadExt: AsyncRead {
     }
 }
 
-impl<S> AsyncReadExt for S
+impl<S> CustomAsyncReadExt for S
 where
     S: AsyncRead {}
 

--- a/components/core-agent/src/tailer/mod.rs
+++ b/components/core-agent/src/tailer/mod.rs
@@ -4,3 +4,4 @@ pub mod tailer;
 pub mod tailer_events;
 pub mod payload;
 pub mod async_read;
+pub mod reader;

--- a/components/core-agent/src/tailer/reader.rs
+++ b/components/core-agent/src/tailer/reader.rs
@@ -19,6 +19,8 @@ pub async fn read_data(
 ) -> std::io::Result<Vec<Bytes>> {
     let file = File::open(&path).await?;
 
+    tokio::pin!(stop);
+
     let mut reader = file.read_until_future(stop);
 
     let mut chunks: Vec<Bytes> = Vec::new();
@@ -26,12 +28,6 @@ pub async fn read_data(
     loop {
         let mut buffer = vec![0u8; READ_BUFFER_SIZE];
 
-        // [TODO-FIX]:
-        // impl std::future::Future<Output = ()> cannot be unpinned
-        // within __ReadUntil<'_, tokio::fs::File, impl std::future::Future<Output = ()>>, the trait Unpin is not implemented for impl std::future::Future<Output = ()>
-        // consider using the pin! macro
-        // consider using Box::pin if you need to access the pinned value outside of the current scope (rustc E0277)
-        // hint: consider restricting opaque type `impl std::future::Future<Output = ()>` with trait `Unpin`: ` + std::marker::Unpin`
         let n = reader.read(&mut buffer).await?;
 
         if n == 0 {

--- a/components/core-agent/src/tailer/reader.rs
+++ b/components/core-agent/src/tailer/reader.rs
@@ -1,0 +1,48 @@
+// Local crates
+use crate::tailer::async_read::CustomAsyncReadExt;
+
+// External crates
+use bytes::Bytes;
+use std::path::PathBuf;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+const READ_BUFFER_SIZE: usize = 16384;
+
+/// Read data from a Tailer's source as Bytes, and return a buffer of the
+/// read bytes. This data is used to consurct the TailerPayload.
+///
+/// See [TailerPayload builder](components/core-agent/src/tailer/payload.rs).
+pub async fn read_data(
+    path: PathBuf,
+    stop: impl std::future::Future<Output = ()>,
+) -> std::io::Result<Vec<Bytes>> {
+    let file = File::open(&path).await?;
+
+    let mut reader = file.read_until_future(stop);
+
+    let mut chunks: Vec<Bytes> = Vec::new();
+
+    loop {
+        let mut buffer = vec![0u8; READ_BUFFER_SIZE];
+
+        // [TODO-FIX]:
+        // impl std::future::Future<Output = ()> cannot be unpinned
+        // within __ReadUntil<'_, tokio::fs::File, impl std::future::Future<Output = ()>>, the trait Unpin is not implemented for impl std::future::Future<Output = ()>
+        // consider using the pin! macro
+        // consider using Box::pin if you need to access the pinned value outside of the current scope (rustc E0277)
+        // hint: consider restricting opaque type `impl std::future::Future<Output = ()>` with trait `Unpin`: ` + std::marker::Unpin`
+        let n = reader.read(&mut buffer).await?;
+
+        if n == 0 {
+            // [TODO]: Handle, EOF or stop condition
+            break;
+        }
+
+        buffer.truncate(n);
+
+        chunks.push(Bytes::from(buffer));
+    }
+
+    Ok(chunks)
+}


### PR DESCRIPTION
- Added new `reader.rs` module, containing `read_data()` method to read data from Tailer sources
- Renamed **AsyncReadExt** trait in `async_read.rs` to **CustomAsyncReadExt**
- Created `read_data()` method to read data from a Tailer's source, currently only files, and return a buffer of the read Bytes, which is then used by `build_payload()` to build the TailerPayload.
- Added `tokio::pin(stop)` in `read_data()` to pin the stop condition to the stack and avoid the stop condition future from not being able to move or be polled.