### PR TITLE
Tailer: send_payload_downstream() method

### DIFF
--- a/components/core-agent/src/tailer/tailer.rs
+++ b/components/core-agent/src/tailer/tailer.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+use tokio::sync::mpsc::error::SendError;
 
 impl Tailer {
     /// Create a new individual Tailer for a specific file(inode)
@@ -85,4 +86,9 @@ pub fn start_tailer(
     return;
 }
 
-// [TODO]: Send TailerPayload to downstream processing...
+async fn send_payload_downstream(
+    payload: TailerPayload,
+    output_channel: &mpsc::Sender<TailerPayload>,
+) -> Result<(), mpsc::error::SendError<TailerPayload>> {
+    output_channel.send(payload).await
+}

--- a/components/core-agent/src/tailer/tailer.rs
+++ b/components/core-agent/src/tailer/tailer.rs
@@ -15,7 +15,6 @@ use std::path::PathBuf;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tokio::sync::mpsc::error::SendError;
 
 impl Tailer {
     /// Create a new individual Tailer for a specific file(inode)


### PR DESCRIPTION
- Created `send_payload_downstream()` method to allow each individual **`Tailer`** to send **`TailerPayloads`** downstream to the next pipeline stage. This method ONLY SENDS **`TailerPayloads`** DOWNSTREAM.