### PR TITLE
TailerReader<F>

### DIFF
--- a/components/core-agent/src/tailer/models.rs
+++ b/components/core-agent/src/tailer/models.rs
@@ -1,9 +1,11 @@
 // Local crates
 use crate::watcher::models::{Checkpoint, WatcherPayload};
+use crate::tailer::async_read::ReadUntil;
 
 // External crates
 use anyhow::Result;
 use bytes::Bytes;
+use tokio::fs::File;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::sync::{broadcast, mpsc};
@@ -79,4 +81,10 @@ pub struct TailerPayload {
     pub size: usize,
 }
 
-// [TODO]: New FileIdentity struct to allow robust file id using Fingerprint
+/// `TailerReader` is a streaming source reader, currently only implemented for file
+/// reads, wraps a source plus "stop" future and reads only new bytes from the source,
+/// incrementally without re-opening the source.
+pub struct TailerReader<F> {
+    pub reader: ReadUntil<File, F>,
+    pub buffer: Vec<u8>,
+}


### PR DESCRIPTION
- Created `TailerReader` to provide a, stop condition-aware, streaming reader for a Tailer's specific source (currently only files).
- Replaced `read_data()` with `impl<F> TailerReader<F>` methods to create new TailerReader and read data from a Tailer's source when the Tailer is running.

> By treating data reads as reads from a stream, running Tailers do not need to re-open their individual source everytime they want to read data from it, as was the case with `read_data()`