### PR TITLE
Tailer::run() method, COMPLETE

### DIFF
--- a/components/core-agent/src/tailer/models.rs
+++ b/components/core-agent/src/tailer/models.rs
@@ -77,7 +77,7 @@ pub struct Tailer {
 /// piece of data read from a file. It is not bytes, not lines necessarily, and not
 /// file metadata.
 pub struct TailerPayload {
-    pub raw_data: Vec<Bytes>,
+    pub raw_data: Bytes,
     pub size: usize,
 }
 

--- a/components/core-agent/src/tailer/payload.rs
+++ b/components/core-agent/src/tailer/payload.rs
@@ -6,14 +6,14 @@ use bytes::Bytes;
 
 #[allow(unused_doc_comments)]
 pub fn build_payload(
-    buffer: Vec<Bytes>,
+    chunk: Bytes,
 ) -> TailerPayload {
 
     /// This is required ONLY for metrics currently
-    let data_size = buffer.iter().map(|b| b.len()).sum();
+    let data_size = chunk.len();
 
     TailerPayload {
-        raw_data: buffer,
+        raw_data: chunk,
         size: data_size,
     }
 }

--- a/components/core-agent/src/tailer/tailer.rs
+++ b/components/core-agent/src/tailer/tailer.rs
@@ -5,6 +5,7 @@ use crate::tailer::{
         Tailer,
         TailerHandle,
         TailerPayload,
+        TailerReader,
     },
     payload::build_payload,
 };
@@ -15,6 +16,7 @@ use std::path::PathBuf;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+use tokio::fs::File;
 
 impl Tailer {
     /// Create a new individual Tailer for a specific file(inode)
@@ -38,14 +40,23 @@ impl Tailer {
     /// which is managed by the `TailerManager`, `Payload` transmission, and
     /// management for an individual running Tailer takes place.
     pub async fn run(self) -> Result<()> {
+        let file = File::open(&self.path).await?;
+
+        // [TODO]: Actually implement the stop condition, LOL ;)
+        let mut reader = TailerReader::new(file, stop);
+
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => {
                     break;
                 }
-                // [TODO]: Build TailerPayload being sent
 
-                // [TODO]: Payload transmission goes here
+                read_data = reader.read_data_chunk() => {
+                    if let Some(data) = read_data? {
+                        let tailer_payload = build_payload(data);
+                        send_payload_downstream(tailer_payload, &self.output).await?;
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
- `Tailer::run()` method is now complete, allowing a running `Tailer` to;
   - Read data from a source (currently only file sources are supported)
   - Build a `TailerPayload` using the data read from a source
   - Send the `TailerPayload` downstream into the next step of the pipeline
  
> A Tailer can now be created/spawned by the `TailerManager` based on received `WatcherEvents` and run (do the work it is supposed to do)