### PR TITLE
Tailer::run() stop_condition for TailerReader instance created in a Tailer's run loop

### DIFF
--- a/components/core-agent/src/tailer/tailer.rs
+++ b/components/core-agent/src/tailer/tailer.rs
@@ -96,6 +96,17 @@ pub fn start_tailer(
     return;
 }
 
+pub fn stop_tailer(
+    inode: u64,
+    tailers: &mut HashMap<Inode, TailerHandle>,
+) {
+    if let Some(tailer_handle) = tailers.remove(&inode) {
+        tailer_handle.cancel.cancel();
+    }
+
+    return;
+}
+
 async fn send_payload_downstream(
     payload: TailerPayload,
     output_channel: &mpsc::Sender<TailerPayload>,

--- a/components/core-agent/src/tailer/tailer_events.rs
+++ b/components/core-agent/src/tailer/tailer_events.rs
@@ -68,7 +68,6 @@ pub async fn handle_event(
         TailerEvent::Stop { inode, path } => {
             stop_tailer(inode, tailers)
         }
-        // [TODO]: Explicitly specify old and new paths
         TailerEvent::Rotate { old_inode, new_inode, path } => {
             stop_tailer(old_inode, tailers);
             start_tailer(new_inode, path, tailers, output, cancel)

--- a/components/core-agent/src/v0.1.0_IMPROVMENTS.md
+++ b/components/core-agent/src/v0.1.0_IMPROVMENTS.md
@@ -1,9 +1,0 @@
-# Final Improvements For v0.1.0 Public Beta
-
-1. Add tracing and tokio-console to monitor program performance.
-2. Add error handling to store logs failed to send to Embedder for various reasons.
-3. Add common integrations; log formats/log producers, NormalizedLog storage options, language support, etc.
-4. Test various log_collector.toml configuration options and record performance, reliability and best/worst practices.
-5. Add basic unit/integration tests, this can be done during the public beta.
-6. Create documentation website.
-7. Add CLA to VES mintlify docs site.


### PR DESCRIPTION
- Deleted outdated `v0.1.0` docs
- Restored `stop_tailer()` method which was previously deleted for some reason
- Deleted unnecessary **[TODO]** instructions in `handle_event()` logic
- Wrapped `self.cancel.cancelled();` used by `Tailer::new()` in a **`std::pin::pin;`** and removed duplicate self.cancel.cancelled() call in tokio::select! {} loop, wrapping `WaitForCancellationFuture<'_>` returned by `.cancelled()` in a `Pin<&mut T>`